### PR TITLE
Refactored raw endpoint calls into a service

### DIFF
--- a/app/components/tag-list.js
+++ b/app/components/tag-list.js
@@ -1,8 +1,10 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import ENV from 'realworld-starter-kit/config/environment';
+import { inject as service } from '@ember/service';
 
 export default class TagListComponent extends Component {
+  @service('authorizedFetch') authorizedFetch;
+
   @tracked tags = [];
   @tracked isLoading = false;
 
@@ -13,8 +15,7 @@ export default class TagListComponent extends Component {
 
   async loadTags() {
     this.isLoading = true;
-    let response = await fetch(`${ENV.APP.apiHost}/tags`);
-    let { tags } = await response.json();
+    let { tags } = await this.authorizedFetch.fetch('/tags');
     this.tags = tags;
     this.isLoading = false;
   }

--- a/app/models/article.js
+++ b/app/models/article.js
@@ -4,7 +4,6 @@ import { tracked } from '@glimmer/tracking';
 import marked from 'marked';
 import { htmlSafe } from '@ember/string';
 import { inject as service } from '@ember/service';
-import ENV from 'realworld-starter-kit/config/environment';
 
 export default class ArticleModel extends Model {
   @tracked title;
@@ -13,6 +12,7 @@ export default class ArticleModel extends Model {
   @tracked tagList;
 
   @service('session') session;
+  @service('authorizedFetch') authorizedFetch;
 
   @attr('string') title;
   @attr('string') description;
@@ -46,13 +46,10 @@ export default class ArticleModel extends Model {
   }
 
   async favoriteOperation(operation) {
-    let response = await fetch(`${ENV.APP.apiHost}/articles/${this.id}/favorite`, {
-      method: operation === 'unfavorite' ? 'DELETE' : 'POST',
-      headers: {
-        Authorization: `Token ${this.session.token}`,
-      },
-    });
-    let { article } = await response.json();
+    let { article } = await this.authorizedFetch.fetch(
+      `/articles/${this.id}/favorite`,
+      operation === 'unfavorite' ? 'DELETE' : 'POST',
+    );
     this.store.pushPayload({
       articles: [Object.assign(article, { id: article.slug })],
     });

--- a/app/models/profile.js
+++ b/app/models/profile.js
@@ -2,12 +2,12 @@ import DS from 'ember-data';
 import { tracked } from '@glimmer/tracking';
 const { Model, attr, hasMany } = DS;
 import { inject as service } from '@ember/service';
-import ENV from 'realworld-starter-kit/config/environment';
 
 export default class UserModel extends Model {
   @tracked articles;
 
   @service('session') session;
+  @service('authorizedFetch') authorizedFetch;
 
   @attr('string') bio;
   @attr('string') image;
@@ -33,13 +33,10 @@ export default class UserModel extends Model {
   }
 
   async followOperation(operation) {
-    let response = await fetch(`${ENV.APP.apiHost}/profiles/${this.id}/follow`, {
-      method: operation === 'follow' ? 'POST' : 'DELETE',
-      headers: {
-        Authorization: `Token ${this.session.token}`,
-      },
-    });
-    let { profile } = await response.json();
+    let { profile } = await this.authorizedFetch.fetch(
+      `/profiles/${this.id}/follow`,
+      operation === 'follow' ? 'POST' : 'DELETE',
+    );
     this.store.pushPayload({
       profiles: [Object.assign(profile, { id: profile.username })],
     });

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -1,6 +1,5 @@
 import DS from 'ember-data';
 const { Model, attr } = DS;
-import ENV from 'realworld-starter-kit/config/environment';
 import { inject as service } from '@ember/service';
 
 export default class UserModel extends Model {
@@ -16,12 +15,7 @@ export default class UserModel extends Model {
   @attr('date') updatedAt;
 
   async fetchFeed(page = 1) {
-    let response = await fetch(`${ENV.APP.apiHost}/articles/feed?page=${page}`, {
-      headers: {
-        Authorization: `Token ${this.session.token}`,
-      },
-    });
-    let { articles } = await response.json();
+    let { articles } = await this.authorizedFetch.fetch(`/articles/feed?page=${page}`);
     if (!articles.length) {
       return [];
     }

--- a/app/services/authorized-fetch.js
+++ b/app/services/authorized-fetch.js
@@ -1,0 +1,18 @@
+import Service from '@ember/service';
+import { inject as service } from '@ember/service';
+import ENV from 'realworld-starter-kit/config/environment';
+
+export default class AuthorizedFetchService extends Service {
+  @service('session') session;
+
+  async fetch(url, method = 'GET') {
+    let response = await fetch(`${ENV.APP.apiHost}${url}`, {
+      method,
+      headers: {
+        Authorization: `Token ${this.session.token}`,
+      },
+    });
+    let payload = await response.json();
+    return payload;
+  }
+}

--- a/app/services/session.js
+++ b/app/services/session.js
@@ -6,6 +6,7 @@ import ENV from 'realworld-starter-kit/config/environment';
 
 export default class SessionService extends Service {
   @service('store') store;
+  @service('authorizedFetch') authorizedFetch;
 
   @tracked token;
   @tracked user;
@@ -79,12 +80,7 @@ export default class SessionService extends Service {
   }
 
   async fetchUser() {
-    let response = await fetch(`${ENV.APP.apiHost}/user`, {
-      headers: {
-        Authorization: `Token ${this.token}`,
-      },
-    });
-    let { user } = await response.json();
+    let { user } = await this.authorizedFetch.fetch('/user');
     this.store.pushPayload({
       users: [user],
     });


### PR DESCRIPTION
Rather than scatter raw authorized `fetch` calls around the codebase I've moved them into a single service call.