### PR TITLE
Fix null token

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -9,7 +9,7 @@ export default class ApplicationAdapter extends RESTAdapter {
   host = ENV.APP.apiHost;
 
   headers = {
-    Authorization: `Token ${this.session.token}`,
+    Authorization: this.session.token ? `Token ${this.session.token}` : '',
   };
 
   handleResponse(status, headers, payload) {

--- a/app/services/authorized-fetch.js
+++ b/app/services/authorized-fetch.js
@@ -9,7 +9,7 @@ export default class AuthorizedFetchService extends Service {
     let response = await fetch(`${ENV.APP.apiHost}${url}`, {
       method,
       headers: {
-        Authorization: `Token ${this.session.token}`,
+        Authorization: this.session.token ? `Token ${this.session.token}` : '',
       },
     });
     let payload = await response.json();


### PR DESCRIPTION
Sending `Token null` causes the backend to 401 if a user is not logged in